### PR TITLE
Añade logger a filtro de excepciones de dominio

### DIFF
--- a/src/infraestructura/excepciones/filtro-excepciones-negocio.ts
+++ b/src/infraestructura/excepciones/filtro-excepciones-negocio.ts
@@ -3,22 +3,30 @@ import {
   Catch,
   ArgumentsHost,
   HttpStatus,
+  Logger,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { ErrorDeNegocio } from 'src/dominio/excepciones/error-de-negocio';
+import { LogMessage } from './log-message';
 
 @Catch(ErrorDeNegocio)
 export class FiltroExcepcionesDeNegocio implements ExceptionFilter {
+  constructor(private logger: Logger) { }
+
   catch(exception: ErrorDeNegocio, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
 
-    response.status(HttpStatus.BAD_REQUEST).json({
+    const logMessage: LogMessage = {
       statusCode: HttpStatus.BAD_REQUEST,
       timestamp: new Date().toISOString(),
       path: request.url,
-      mensaje: exception.message,
-    });
+      message: exception.message
+    };
+
+    this.logger.log(logMessage);
+
+    response.status(HttpStatus.BAD_REQUEST).json(logMessage);
   }
 }

--- a/src/infraestructura/excepciones/log-message.ts
+++ b/src/infraestructura/excepciones/log-message.ts
@@ -1,0 +1,6 @@
+export interface LogMessage {
+  statusCode: number;
+  timestamp: string;
+  path: string;
+  message: string;
+}

--- a/src/infraestructura/infraestructura.module.ts
+++ b/src/infraestructura/infraestructura.module.ts
@@ -1,8 +1,9 @@
-import { Module } from '@nestjs/common';
+import { Module, Logger } from '@nestjs/common';
 import { UsuarioModule } from './usuario/usuario.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
+  providers: [Logger],
   imports: [TypeOrmModule.forRoot(), UsuarioModule],
 })
 export class InfraestructuraModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,14 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { FiltroExcepcionesDeNegocio } from './infraestructura/excepciones/filtro-excepciones-negocio';
+import { Logger } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.useGlobalFilters(new FiltroExcepcionesDeNegocio());
+  const logger = app.get(Logger);
+
+  app.useGlobalFilters(new FiltroExcepcionesDeNegocio(logger));
+
   await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
Se añade el logger por defecto de Nest:

![image](https://user-images.githubusercontent.com/11398826/76339968-d2552c80-62c8-11ea-9ef1-fd5c06ed91ec.png)

En caso de necesitarse algo más avanzado, se puede crear una [implementación propia](https://docs.nestjs.com/techniques/logger#custom-implementation) o [extender ](https://docs.nestjs.com/techniques/logger#extend-built-in-logger)el logger que viene con el framework.